### PR TITLE
Add schema validation case for two AI slots in game creation

### DIFF
--- a/server/schemas/game.py
+++ b/server/schemas/game.py
@@ -95,6 +95,11 @@ class CreateGameInput(Schema):
 
         assert_player_exists(value)
 
+    @validates_schema
+    def two_ai_players(self, data):
+        if data['player1_id'] == 'AI' and data['player2_id'] == 'AI':
+            raise ValidationError('Cannot create a game with two AI slots.')
+
     @validates('creator_id')
     def creator_exists(self, value):
         assert_player_exists(value)

--- a/server/schemas/game.py
+++ b/server/schemas/game.py
@@ -97,8 +97,12 @@ class CreateGameInput(Schema):
 
     @validates_schema
     def two_ai_players(self, data):
-        if data['player1_id'] == 'AI' and data['player2_id'] == 'AI':
-            raise ValidationError('Cannot create a game with two AI slots.')
+        # FIXME: Needed to have this outer condition for some reason.
+        #   Python didn't seem to find these keys in the dict for one of the
+        #   test cases, even though they were in the dict.
+        if ('player1_id' in data) and ('player2_id' in data):
+            if data['player1_id'] == 'AI' and data['player2_id'] == 'AI':
+                raise ValidationError('Cannot create a game with two AI slots.')
 
     @validates('creator_id')
     def creator_exists(self, value):

--- a/test/routes/test_create_game.py
+++ b/test/routes/test_create_game.py
@@ -74,6 +74,15 @@ class CreateGameTest(unittest.TestCase):
         response = self.post(params)
         self.assertEqual(BAD_REQUEST, response.status_code)
 
+    def test_two_ais(self, mock_db, mock_auth):
+        """Two AI slots should error"""
+        self.set_up_mock(mock_db, mock_auth)
+        params = self.create_dummy_params()
+        params["player1_id"] = "AI"
+        params["player2_id"] = "AI"
+        response = self.post(params)
+        self.assertEqual(BAD_REQUEST, response.status_code)
+
     def test_negative_time_per_player(self, mock_db, mock_auth):
         """Having negative time_per_player should error"""
         self.set_up_mock(mock_db, mock_auth)


### PR DESCRIPTION
# Description

Adds an extra validation condition to the schema for `/creategame` to handle the case described in #61 (a game with AIs occupying both player slots).

This now results in a `ValidationError` (which leads to a `BAD REQUEST`) rather than a `RuntimeError`.